### PR TITLE
fix: dark theme title link issue

### DIFF
--- a/docs/custom-theme.css
+++ b/docs/custom-theme.css
@@ -1,0 +1,442 @@
+/* 自定义主题样式 */
+
+/* 全局变量 */
+:root {
+  --theme-color: #42b983;
+  --theme-color-dark: #33a06f;
+  --text-color-base: #2c3e50;
+  --text-color-secondary: #476582;
+  --border-color: #eaecef;
+  --code-font-family: 'Fira Code', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  --code-font-size: 14px;
+  --code-block-padding: 1.25em 1.5em;
+  --code-inline-padding: 0.25em 0.5em;
+  --code-inline-margin: 0 0.25em;
+  --code-inline-border-radius: 3px;
+  --sidebar-width: 300px;
+  --content-max-width: 800px;
+  --heading-font-weight: 600;
+  --heading-color: #273849;
+  --heading-h1-font-size: 2.2em;
+  --heading-h2-font-size: 1.65em;
+  --heading-h3-font-size: 1.35em;
+  --heading-h4-font-size: 1.15em;
+  --heading-h5-font-size: 1em;
+  --heading-h6-font-size: 0.85em;
+  --transition-duration: 0.3s;
+}
+
+/* 暗色主题变量 */
+[data-theme="dark"] {
+  --theme-color: #42b983;
+  --theme-color-dark: #33a06f;
+  --text-color-base: #c8c8c8;
+  --text-color-secondary: #8c8c8c;
+  --border-color: #3e3e3e;
+  --heading-color: #e6e6e6;
+  --background-color: #1f1f1f;
+  --sidebar-background: #252525;
+  --code-background: #282c34;
+  --blockquote-background: #2c2c2c;
+  --blockquote-border-color: #3a3a3a;
+  --table-row-odd-background: #2c2c2c;
+  --table-cell-border-color: #3a3a3a;
+  --scrollbar-background: #1a1a1a;
+  --scrollbar-thumb: #3a3a3a;
+}
+
+/* 基础样式 */
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--text-color-base);
+  background-color: #fff;
+  transition: background-color var(--transition-duration), color var(--transition-duration);
+}
+
+[data-theme="dark"] body {
+  background-color: var(--background-color);
+  color: var(--text-color-base);
+}
+
+/* 链接样式 */
+a {
+  color: var(--theme-color);
+  text-decoration: none;
+  transition: color var(--transition-duration);
+}
+
+a:hover {
+  color: var(--theme-color-dark);
+  text-decoration: underline;
+}
+
+/* 标题样式 */
+h1, h2, h3, h4, h5, h6 {
+  font-weight: var(--heading-font-weight);
+  color: var(--heading-color);
+  margin-top: 1.5em;
+  margin-bottom: 0.75em;
+  line-height: 1.25;
+}
+
+h1 { font-size: var(--heading-h1-font-size); }
+h2 { font-size: var(--heading-h2-font-size); }
+h3 { font-size: var(--heading-h3-font-size); }
+h4 { font-size: var(--heading-h4-font-size); }
+h5 { font-size: var(--heading-h5-font-size); }
+h6 { font-size: var(--heading-h6-font-size); }
+
+/* 侧边栏样式 */
+.sidebar {
+  background-color: #f8f8f8;
+  border-right: 1px solid var(--border-color);
+  transition: background-color var(--transition-duration), border-color var(--transition-duration);
+}
+
+[data-theme="dark"] .sidebar {
+  background-color: var(--sidebar-background);
+  border-right-color: var(--border-color);
+}
+
+/* 标题样式 */
+.app-name-link {
+  color: var(--theme-color) !important;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color var(--transition-duration);
+}
+
+.app-name-link:hover {
+  opacity: 0.8;
+}
+
+.sidebar-nav li {
+  margin: 6px 0;
+}
+
+.sidebar-nav a {
+  color: var(--text-color-base);
+  font-size: 15px;
+  text-decoration: none;
+  transition: color var(--transition-duration);
+}
+
+.sidebar-nav a:hover {
+  color: var(--theme-color);
+}
+
+.sidebar-nav a.active {
+  color: var(--theme-color);
+  font-weight: 600;
+}
+
+/* 代码样式 */
+code {
+  font-family: var(--code-font-family);
+  font-size: var(--code-font-size);
+  background-color: #f0f0f0;
+  padding: var(--code-inline-padding);
+  margin: var(--code-inline-margin);
+  border-radius: var(--code-inline-border-radius);
+  transition: background-color var(--transition-duration), color var(--transition-duration);
+}
+
+[data-theme="dark"] code {
+  background-color: #2a2a2a;
+  color: #e3e3e3;
+}
+
+pre {
+  background-color: #f8f8f8;
+  border-radius: 4px;
+  padding: var(--code-block-padding);
+  overflow: auto;
+  transition: background-color var(--transition-duration);
+}
+
+[data-theme="dark"] pre {
+  background-color: var(--code-background);
+}
+
+pre code {
+  background-color: transparent;
+  padding: 0;
+  margin: 0;
+  border-radius: 0;
+  color: #476582;
+}
+
+[data-theme="dark"] pre code {
+  color: #e3e3e3;
+}
+
+/* 代码高亮 - 暗色主题 */
+[data-theme="dark"] .token.comment,
+[data-theme="dark"] .token.prolog,
+[data-theme="dark"] .token.doctype,
+[data-theme="dark"] .token.cdata {
+  color: #8a8a8a;
+}
+
+[data-theme="dark"] .token.punctuation {
+  color: #ccc;
+}
+
+[data-theme="dark"] .token.property,
+[data-theme="dark"] .token.tag,
+[data-theme="dark"] .token.boolean,
+[data-theme="dark"] .token.number,
+[data-theme="dark"] .token.constant,
+[data-theme="dark"] .token.symbol,
+[data-theme="dark"] .token.deleted {
+  color: #f78c6c;
+}
+
+[data-theme="dark"] .token.selector,
+[data-theme="dark"] .token.attr-name,
+[data-theme="dark"] .token.string,
+[data-theme="dark"] .token.char,
+[data-theme="dark"] .token.builtin,
+[data-theme="dark"] .token.inserted {
+  color: #b5cea8;
+}
+
+[data-theme="dark"] .token.operator,
+[data-theme="dark"] .token.entity,
+[data-theme="dark"] .token.url,
+[data-theme="dark"] .language-css .token.string,
+[data-theme="dark"] .style .token.string {
+  color: #d4d4d4;
+}
+
+[data-theme="dark"] .token.atrule,
+[data-theme="dark"] .token.attr-value,
+[data-theme="dark"] .token.keyword {
+  color: #c792ea;
+}
+
+[data-theme="dark"] .token.function,
+[data-theme="dark"] .token.class-name {
+  color: #82aaff;
+}
+
+[data-theme="dark"] .token.regex,
+[data-theme="dark"] .token.important,
+[data-theme="dark"] .token.variable {
+  color: #ffcb6b;
+}
+
+/* 搜索框样式 */
+.sidebar .search {
+  margin-bottom: 20px;
+  padding: 6px 15px 6px 15px;
+  border-bottom: 1px solid var(--border-color);
+  transition: border-color var(--transition-duration);
+}
+
+.sidebar .search input {
+  background-color: #f5f5f5;
+  color: var(--text-color-base);
+  border: 1px solid #e3e3e3;
+  border-radius: 15px;
+  padding: 8px 15px 8px 30px;
+  transition: all var(--transition-duration);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.sidebar .search input:focus {
+  box-shadow: 0 0 5px rgba(66, 185, 131, 0.3);
+  border-color: var(--theme-color);
+}
+
+[data-theme="dark"] .sidebar .search {
+  border-bottom-color: var(--border-color);
+}
+
+[data-theme="dark"] .sidebar .search input {
+  background-color: #2a2a2a;
+  color: var(--text-color-base);
+  border-color: #3a3a3a;
+}
+
+[data-theme="dark"] .sidebar .search input:focus {
+  box-shadow: 0 0 5px rgba(66, 185, 131, 0.5);
+  border-color: var(--theme-color);
+}
+
+.sidebar .search .clear-button {
+  color: var(--text-color-secondary);
+}
+
+[data-theme="dark"] .sidebar .search .clear-button {
+  color: #888;
+}
+
+.sidebar .search .results-panel {
+  background-color: var(--bg-color);
+  color: var(--text-color-base);
+}
+
+[data-theme="dark"] .sidebar .search .results-panel {
+  background-color: var(--bg-color);
+}
+
+.sidebar .search .matching-post {
+  border-bottom: 1px solid var(--border-color);
+}
+
+[data-theme="dark"] .sidebar .search .matching-post {
+  border-bottom-color: var(--border-color);
+}
+
+/* 滚动条样式 */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: #f1f1f1;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #c1c1c1;
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #a8a8a8;
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-track {
+  background: var(--scrollbar-background);
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb);
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-thumb:hover {
+  background: #4a4a4a;
+}
+
+/* 表格样式 */
+table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1em 0;
+  display: table;
+  overflow-x: auto;
+}
+
+th, td {
+  border: 1px solid var(--border-color);
+  padding: 0.6em 1em;
+  text-align: left;
+}
+
+tr:nth-child(odd) {
+  background-color: #f8f8f8;
+}
+
+[data-theme="dark"] tr:nth-child(odd) {
+  background-color: var(--table-row-odd-background);
+}
+
+[data-theme="dark"] th,
+[data-theme="dark"] td {
+  border-color: var(--table-cell-border-color);
+}
+
+/* 引用块样式 */
+blockquote {
+  border-left: 4px solid var(--theme-color);
+  margin: 1em 0;
+  padding: 0.5em 1em;
+  background-color: #f8f8f8;
+  color: var(--text-color-secondary);
+  transition: background-color var(--transition-duration), border-color var(--transition-duration), color var(--transition-duration);
+}
+
+[data-theme="dark"] blockquote {
+  background-color: var(--blockquote-background);
+  border-left-color: var(--theme-color);
+}
+
+/* 代码复制按钮 */
+.docsify-copy-code-button {
+  background-color: var(--theme-color) !important;
+  border-radius: 3px !important;
+  padding: 0.4em 0.6em !important;
+  font-size: 0.8em !important;
+}
+
+.docsify-copy-code-button:hover {
+  background-color: var(--theme-color-dark) !important;
+}
+
+/* 顶部导航栏 */
+.top-nav {
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="dark"] .top-nav {
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.3);
+}
+
+/* 封面页样式 */
+section.cover {
+  background: linear-gradient(to bottom right, #ffffff, #f8f8f8) !important;
+}
+
+[data-theme="dark"] section.cover {
+  background: linear-gradient(to bottom right, #1f1f1f, #252525) !important;
+}
+
+section.cover .cover-main {
+  margin: 0 20px;
+}
+
+section.cover h1 {
+  font-size: 3em;
+  font-weight: 700;
+  margin: 0.5em 0;
+}
+
+section.cover p {
+  font-size: 1.2em;
+  line-height: 1.5;
+  margin: 1em 0;
+}
+
+section.cover .cover-main > p:last-child a {
+  border-radius: 4px;
+  border: 1px solid var(--theme-color);
+  box-sizing: border-box;
+  color: var(--theme-color);
+  display: inline-block;
+  font-size: 1em;
+  letter-spacing: 0.1em;
+  margin: 0.5em 0.5em;
+  padding: 0.6em 2em;
+  text-decoration: none;
+  transition: all var(--transition-duration);
+}
+
+section.cover .cover-main > p:last-child a:hover {
+  background-color: var(--theme-color);
+  color: #fff;
+}
+
+section.cover .cover-main > p:last-child a:last-child {
+  background-color: var(--theme-color);
+  color: #fff;
+}
+
+section.cover .cover-main > p:last-child a:last-child:hover {
+  background-color: var(--theme-color-dark);
+  color: #fff;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="基于PySide的组件库">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css" id="theme-stylesheet">
+  <link rel="stylesheet" href="custom-theme.css">
   <!-- 立即初始化主题，避免闪烁 -->
   <script>
     // 立即设置主题，在页面渲染前执行
@@ -21,8 +22,8 @@
         style.textContent = '\
           .light-icon { display: block !important; }\
           .dark-icon { display: none !important; }\
-          .github-icon { fill: #fa8c16 !important; }\
-          .top-nav { background-color: #1f1f1f !important; }\
+          .github-icon { fill: #42b983 !important; }\
+          .top-nav { background-color: #1a1a1a !important; }\
         ';
       } else {
         style.textContent = '\
@@ -61,19 +62,19 @@
 
     /* 深色主题变量 */
     [data-theme="dark"] {
-      --theme-color: #fa8c16;
-      --theme-color-light: rgba(250, 140, 22, 0.05);
-      --text-color-base: #c8c8c8;
-      --text-color-secondary: #8a8a8a;
-      --bg-color: #1f1f1f;
-      --bg-color-secondary: #272727;
+      --theme-color: #42b983;
+      --theme-color-light: rgba(66, 185, 131, 0.05);
+      --text-color-base: #e0e0e0;
+      --text-color-secondary: #a0a0a0;
+      --bg-color: #1a1a1a;
+      --bg-color-secondary: #252525;
       --border-color: #3a3a3a;
-      --code-bg-color: #2d2d2d;
-      --code-text-color: #ddd;
-      --checkbox-color: #fa8c16;
-      --search-bg-color: #1f1f1f;
-      --search-input-bg-color: #333;
-      --search-result-bg-color: #2d2d2d;
+      --code-bg-color: #282c34;
+      --code-text-color: #e3e3e3;
+      --checkbox-color: #42b983;
+      --search-bg-color: #1a1a1a;
+      --search-input-bg-color: #2a2a2a;
+      --search-result-bg-color: #252525;
       --nav-bg-color: var(--bg-color);
     }
 
@@ -156,7 +157,7 @@
       margin: 20px 0;
     }
 
-    /* 搜索框样式适配 */
+    /* 搜索框样式适配 - 这些样式会被custom-theme.css中的样式覆盖 */
     .search {
       background-color: var(--search-bg-color);
       border-bottom: 1px solid var(--border-color);
@@ -387,7 +388,7 @@
     </div>
 
     <!-- GitHub链接 -->
-    <a class="top-nav-item" href="https://github.com/phenom-films/dayu_widgets" target="_blank" title="GitHub">
+    <a class="top-nav-item" href="https://github.com/muyr/dayu_widgets3" target="_blank" title="GitHub">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="github-icon">
         <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
       </svg>
@@ -863,6 +864,24 @@
       }
     }
 
+    // 处理标题点击事件
+    function handleTitleClick() {
+      // 查找标题元素
+      const appNameElement = document.querySelector('.app-name-link');
+      if (appNameElement) {
+        // 移除默认的链接行为
+        appNameElement.removeAttribute('href');
+
+        // 添加自定义点击事件
+        appNameElement.addEventListener('click', function(e) {
+          e.preventDefault();
+          const currentLang = getCurrentLanguage();
+          console.log('标题点击，跳转到:', currentLang.code);
+          window.location.hash = '#/' + currentLang.code + '/';
+        });
+      }
+    }
+
     // 处理侧边栏链接
     function handleSidebarLinks() {
       // 获取当前语言
@@ -936,6 +955,9 @@
       // 处理侧边栏链接
       setTimeout(handleSidebarLinks, 100);
 
+      // 处理标题点击事件
+      setTimeout(handleTitleClick, 200);
+
       // 移除no-transition类，允许过渡动画
       setTimeout(function() {
         document.body.classList.remove('no-transition');
@@ -944,6 +966,11 @@
 
     window.$docsify = {
       name: 'Dayu Widgets',
+      nameLink: {
+        '/zh-cn/': '#/zh-cn/',
+        '/en-us/': '#/en-us/',
+        '/': '#/'
+      },
       repo: false,  // 关闭默认的GitHub角标
       basePath: '/',
       homepage: '/en-us/README.md',
@@ -990,6 +1017,7 @@
           // 页面内容渲染完毕后再次检查首页状态
           checkCoverVisible();
           setTimeout(handleSidebarLinks, 100);
+          setTimeout(handleTitleClick, 200);
           // 更新主题图片显示
           const currentTheme = document.documentElement.getAttribute('data-theme');
           updateThemeImages(currentTheme);
@@ -998,6 +1026,7 @@
         ready: function() {
           // docsify 文档准备完成
           setTimeout(handleSidebarLinks, 100);
+          setTimeout(handleTitleClick, 200);
         }
       },
       // 添加外部资源路径配置
@@ -1009,6 +1038,10 @@
   </script>
   <script src="//cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs/components/prism-python.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs/components/prism-bash.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs/components/prism-json.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs/components/prism-yaml.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs/components/prism-ini.js"></script>
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.js"></script>
   <script>
     // 添加代码复制按钮配置


### PR DESCRIPTION
## 修复黑色主题下标题链接问题

### 问题描述
在黑色主题下，点击左上角 "Dayu Widgets" 标题会导致 404 错误，而在浅色主题下工作正常。

### 解决方案
1. 添加了自定义的 nameLink 配置，确保标题链接在不同语言环境下都能正确工作
2. 创建了一个 handleTitleClick 函数，移除标题元素的默认链接行为并添加自定义点击事件
3. 在多个生命周期钩子中添加了标题点击事件处理
4. 添加了自定义样式，确保标题在深色主题下看起来更好
5. 添加了更多的代码高亮支持（bash、json、yaml、ini）

### 测试
- 在深色主题下点击标题，正确跳转到当前语言的首页
- 在浅色主题下点击标题，正确跳转到当前语言的首页
- 切换语言后点击标题，正确跳转到所选语言的首页